### PR TITLE
Extend svsm version to PCR0 before L2 OVMF

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -33,12 +33,13 @@ lazy_static.workspace = true
 bitfield-struct.workspace = true
 
 libmstpm = { workspace = true, optional = true }
+sha2 = { version = "0.10.6", default-features = false, features = ["force-soft"], optional = true }
 
 [target."x86_64-unknown-none".dev-dependencies]
 test.workspace = true
 
 [features]
-default = ["mstpm", "mstpm_crb"]
+default = ["mstpm", "mstpm_crb", "sha2"]
 default-test = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 fuzzing-hooks = []

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -50,6 +50,7 @@ use svsm::sev::{init_hypervisor_ghcb_features, secrets_page, secrets_page_mut, s
 use svsm::svsm_console::{SVSMIOPort, SVSMTdIOPort};
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::{create_kernel_task, schedule_init, TASK_FLAG_SHARE_PT};
+use svsm::tdx::extend_svsm_version;
 use svsm::tdx::run_tdpvp;
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
@@ -506,6 +507,8 @@ pub extern "C" fn svsm_main() {
 
     #[cfg(feature = "mstpm_crb")]
     vtpm::ptp::vtpm_init();
+
+    extend_svsm_version();
 
     virt_log_usage();
 

--- a/kernel/src/tdx/measurement.rs
+++ b/kernel/src/tdx/measurement.rs
@@ -1,0 +1,146 @@
+// Copyright (c) 2022 - 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+use crate::vtpm::tpm_cmd::tpm2_command::Tpm2ResponseHeader;
+use crate::vtpm::tpm_cmd::tpm2_digests::{
+    Tpm2Digest, Tpm2Digests, TPM2_HASH_ALG_ID_SHA384, TPM2_SHA384_SIZE,
+};
+use crate::vtpm::tpm_cmd::tpm2_extend::{tpm2_pcr_extend_cmd, MAX_TPM_PCR_EXTEND_CMD_SIZE};
+use crate::vtpm::tpm_cmd::{
+    TPM2_COMMAND_HEADER_SIZE, TPM2_RESPONSE_HEADER_SIZE, TPM_RC_SUCCESS, TPM_STARTUP_CMD,
+};
+use crate::vtpm::{vtpm_get_locked, MsTpmSimulatorInterface};
+
+pub(crate) type Result<T> = core::result::Result<T, Error>;
+
+#[cfg(feature = "sha2")]
+use sha2::{Digest, Sha384};
+
+#[derive(Debug, Clone, Copy)]
+pub enum Error {
+    StartupTpm,
+    ExtendSvsm,
+    Hash,
+}
+
+fn hash_sha384(hash_data: &str, digest_sha384: &mut [u8; TPM2_SHA384_SIZE]) -> Result<()> {
+    let mut digest = Sha384::new();
+    digest.update(hash_data);
+    let digest = digest.finalize();
+    if digest.len() != TPM2_SHA384_SIZE {
+        log::error!("Hash SVSM version fail!");
+        Err(Error::Hash)
+    } else {
+        digest_sha384.clone_from_slice(digest.as_slice());
+        Ok(())
+    }
+}
+
+fn tpm_startup() -> Result<()> {
+    let backend = vtpm_get_locked();
+
+    // Send TPM_STARTUP CMD
+    let mut tpm_startup_cmd = TPM_STARTUP_CMD;
+    if backend
+        .send_tpm_command(&mut tpm_startup_cmd, &mut TPM_STARTUP_CMD.len(), 0)
+        .is_ok()
+    {
+        let mut response: [u8; TPM2_COMMAND_HEADER_SIZE] = [0; TPM2_COMMAND_HEADER_SIZE];
+        response.copy_from_slice(&tpm_startup_cmd[..TPM2_RESPONSE_HEADER_SIZE]);
+
+        let res = Tpm2ResponseHeader::try_from(response);
+        let rsp = if let Ok(r) = res {
+            r
+        } else {
+            log::error!("Tpm2 Startup failed!\n");
+            return Err(Error::StartupTpm);
+        };
+
+        // Check TPM response code
+        if rsp.response_code != TPM_RC_SUCCESS {
+            log::error!("Tpm2 Startup failed!\n");
+            return Err(Error::StartupTpm);
+        } else {
+            Ok(())
+        }
+    } else {
+        log::error!("send Stratup request fail!\n");
+        return Err(Error::StartupTpm);
+    }
+}
+
+fn tpm_extend(digests: &Tpm2Digests) -> Result<()> {
+    // Get Tpm2Digests
+    let mut cmd_buff = [0u8; MAX_TPM_PCR_EXTEND_CMD_SIZE];
+    let mut tpm_cmd_size = if let Ok(cmd_size) = tpm2_pcr_extend_cmd(digests, 0, &mut cmd_buff) {
+        cmd_size
+    } else {
+        return Err(Error::ExtendSvsm);
+    };
+
+    let backend = vtpm_get_locked();
+    // Send PCR_EXTEND CMD
+    if backend
+        .send_tpm_command(&mut cmd_buff, &mut tpm_cmd_size, 0)
+        .is_ok()
+    {
+        let mut response: [u8; TPM2_COMMAND_HEADER_SIZE] = [0; TPM2_COMMAND_HEADER_SIZE];
+        response.copy_from_slice(&cmd_buff[..TPM2_RESPONSE_HEADER_SIZE]);
+
+        let res = Tpm2ResponseHeader::try_from(response);
+        log::info!("send pcr extend request success:{:02x?}\n", &response);
+
+        let rsp = if let Ok(r) = res {
+            r
+        } else {
+            return Err(Error::ExtendSvsm);
+        };
+
+        // Check TPM response code
+        if rsp.response_code != TPM_RC_SUCCESS {
+            log::error!("Tpm2PcrExtend failed.\n");
+            return Err(Error::ExtendSvsm);
+        } else {
+            Ok(())
+        }
+    } else {
+        log::error!("send pcr extend request fail!\n");
+        return Err(Error::ExtendSvsm);
+    }
+}
+
+pub fn extend_svsm_version() -> Result<()> {
+    let version = env!("CARGO_PKG_VERSION");
+    log::info!("SVSM Version: {:?}", &version);
+
+    let mut svsm_version_digests = Tpm2Digests::new();
+    let mut digest_sha384 = [0u8; TPM2_SHA384_SIZE];
+
+    if hash_sha384(version, &mut digest_sha384).is_ok() {
+        let hashed_version_digest_sha384 =
+            if let Some(digest) = Tpm2Digest::new(TPM2_HASH_ALG_ID_SHA384, &digest_sha384[..]) {
+                digest
+            } else {
+                return Err(Error::Hash);
+            };
+        if svsm_version_digests
+            .push_digest(&hashed_version_digest_sha384)
+            .is_ok()
+        {
+            log::debug!("SVSM extension digests: {:02x?}", &svsm_version_digests);
+        } else {
+            return Err(Error::Hash);
+        }
+    } else {
+        return Err(Error::Hash);
+    }
+
+    if tpm_startup().is_err() {
+        return Err(Error::ExtendSvsm);
+    }
+
+    if tpm_extend(&svsm_version_digests).is_err() {
+        return Err(Error::ExtendSvsm);
+    }
+    Ok(())
+}

--- a/kernel/src/tdx/mod.rs
+++ b/kernel/src/tdx/mod.rs
@@ -11,6 +11,7 @@ mod gmem;
 mod instr_emul;
 mod interrupts;
 mod ioreq;
+mod measurement;
 mod msr_bitmap;
 mod opcode;
 mod percpu;
@@ -30,6 +31,7 @@ mod vmcs_lib;
 mod vmexit;
 mod vmsr;
 
+pub use measurement::extend_svsm_version;
 pub use percpu::{run_tdpvp, TdPerCpu};
 pub use tdcall::{
     td_accept_memory, td_shared_mask, tdcall_get_ve_info, tdvmcall_cpuid, tdvmcall_halt,

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -10,6 +10,7 @@
 /// TPM 2.0 Reference Implementation by Microsoft
 pub mod mstpm;
 pub mod ptp;
+pub mod tpm_cmd;
 
 use crate::vtpm::mstpm::MsTpm as Vtpm;
 use crate::{locking::LockGuard, protocols::vtpm::TpmPlatformCommand};

--- a/kernel/src/vtpm/tpm_cmd/mod.rs
+++ b/kernel/src/vtpm/tpm_cmd/mod.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 - 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod tpm2_command;
+pub mod tpm2_digests;
+pub mod tpm2_extend;
+
+pub const TPM2_COMMAND_HEADER_SIZE: usize = 10;
+pub const TPM2_RESPONSE_HEADER_SIZE: usize = 10;
+pub const TPM_ST_NO_SESSIONS: u16 = 0x8001;
+pub const TPM_ST_SESSIONS: u16 = 0x8002;
+
+pub const TPM_CC_STARTUP: u32 = 0x144;
+pub const TPM_SU_CLEAR: u16 = 0u16;
+pub const TPM_SU_STATE: u16 = 1u16;
+pub const TPM_RC_SUCCESS: u32 = 0;
+
+/// TPM Startup
+pub const TPM_STARTUP_CMD: [u8; 12] = [
+    0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x44, 0x00, 0x00,
+];
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum VtpmError {
+    /// Buffer too small
+    Truncated,
+
+    /// Out of Resource
+    OutOfResource,
+
+    /// Vmm error
+    VmmError,
+
+    /// Spdm error
+    SpdmError,
+
+    /// PipeError
+    PipeError,
+
+    /// Invalid param
+    InvalidParameter,
+
+    ///
+    ExceedMaxConnection,
+
+    ///
+    ExceedMaxTpmInstanceCount,
+
+    ///
+    TpmLibError,
+
+    Unknown,
+}
+pub type VtpmResult<T = ()> = Result<T, VtpmError>;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum TdVtpmOperation {
+    None = 0,
+    Communicate = 1,
+    Create = 2,
+    Destroy = 3,
+    Migration = 4,
+    Invalid = 0xff,
+}
+
+impl TryFrom<u8> for TdVtpmOperation {
+    type Error = VtpmError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(TdVtpmOperation::None),
+            1 => Ok(TdVtpmOperation::Communicate),
+            2 => Ok(TdVtpmOperation::Create),
+            3 => Ok(TdVtpmOperation::Destroy),
+            4 => Ok(TdVtpmOperation::Migration),
+            _ => Err(VtpmError::InvalidParameter),
+        }
+    }
+}

--- a/kernel/src/vtpm/tpm_cmd/tpm2_command.rs
+++ b/kernel/src/vtpm/tpm_cmd/tpm2_command.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2022 - 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::{Into, TryFrom};
+
+use crate::vtpm::tpm_cmd::VtpmError;
+
+use crate::vtpm::tpm_cmd::{TPM2_COMMAND_HEADER_SIZE, TPM2_RESPONSE_HEADER_SIZE};
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct Tpm2CommandHeader {
+    pub tag: u16,
+    pub param_size: u32,
+    pub command_code: u32,
+}
+
+impl Tpm2CommandHeader {
+    pub fn new(tag: u16, param_size: u32, command_code: u32) -> Tpm2CommandHeader {
+        Self {
+            tag,
+            param_size,
+            command_code,
+        }
+    }
+}
+
+impl TryFrom<[u8; TPM2_COMMAND_HEADER_SIZE]> for Tpm2CommandHeader {
+    type Error = VtpmError;
+
+    fn try_from(bytes: [u8; TPM2_COMMAND_HEADER_SIZE]) -> Result<Self, VtpmError> {
+        let tag = u16::from_be_bytes([bytes[0], bytes[1]]);
+        let param_size = u32::from_be_bytes([bytes[2], bytes[3], bytes[4], bytes[5]]);
+        let command_code = u32::from_be_bytes([bytes[6], bytes[7], bytes[8], bytes[9]]);
+
+        // log::info!(">> {0:X?}, {1:X?}, {2:X?}\n", tag, param_size, command_code);
+
+        Ok(Tpm2CommandHeader {
+            tag,
+            param_size,
+            command_code,
+        })
+    }
+}
+
+impl Into<[u8; TPM2_COMMAND_HEADER_SIZE]> for Tpm2CommandHeader {
+    fn into(self) -> [u8; TPM2_COMMAND_HEADER_SIZE] {
+        let tag = self.tag.to_be_bytes();
+        let param_size = self.param_size.to_be_bytes();
+        let command_code = self.command_code.to_be_bytes();
+
+        let mut bytes = [0u8; TPM2_COMMAND_HEADER_SIZE];
+        bytes[..2].copy_from_slice(&tag);
+        bytes[2..6].copy_from_slice(&param_size);
+        bytes[6..TPM2_COMMAND_HEADER_SIZE].copy_from_slice(&command_code);
+
+        bytes
+    }
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct Tpm2ResponseHeader {
+    pub tag: u16,
+    pub param_size: u32,
+    pub response_code: u32,
+}
+
+impl TryFrom<[u8; TPM2_RESPONSE_HEADER_SIZE]> for Tpm2ResponseHeader {
+    type Error = VtpmError;
+
+    fn try_from(bytes: [u8; TPM2_RESPONSE_HEADER_SIZE]) -> Result<Self, VtpmError> {
+        let tag = u16::from_be_bytes([bytes[0], bytes[1]]);
+        let param_size = u32::from_be_bytes([bytes[2], bytes[3], bytes[4], bytes[5]]);
+        let response_code = u32::from_be_bytes([bytes[6], bytes[7], bytes[8], bytes[9]]);
+
+        Ok(Tpm2ResponseHeader {
+            tag,
+            param_size,
+            response_code,
+        })
+    }
+}
+
+impl Into<[u8; TPM2_RESPONSE_HEADER_SIZE]> for Tpm2ResponseHeader {
+    fn into(self) -> [u8; TPM2_RESPONSE_HEADER_SIZE] {
+        let tag = self.tag.to_le_bytes();
+        let param_size = self.param_size.to_be_bytes();
+        let response_code = self.response_code.to_be_bytes();
+
+        let mut bytes = [0u8; TPM2_RESPONSE_HEADER_SIZE];
+        bytes[..2].copy_from_slice(&tag);
+        bytes[2..6].copy_from_slice(&param_size);
+        bytes[6..TPM2_RESPONSE_HEADER_SIZE].copy_from_slice(&response_code);
+
+        bytes
+    }
+}

--- a/kernel/src/vtpm/tpm_cmd/tpm2_digests.rs
+++ b/kernel/src/vtpm/tpm_cmd/tpm2_digests.rs
@@ -1,0 +1,155 @@
+// Copyright (c) 2022 - 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+extern crate alloc;
+use crate::vtpm::tpm_cmd::{VtpmError, VtpmResult};
+use alloc::vec::Vec;
+
+pub const TPM2_HASH_ALG_ID_SHA1: u16 = 0x4;
+pub const TPM2_HASH_ALG_ID_SHA256: u16 = 0xb;
+pub const TPM2_HASH_ALG_ID_SHA384: u16 = 0xc;
+pub const TPM2_HASH_ALG_ID_SHA512: u16 = 0xd;
+
+pub const TPM2_SUPPORTED_HASH_COUNT: usize = 4;
+pub const MAX_TPM2_DIGESTS_SIZE: usize = (MAX_TPM2_HASH_SIZE + 2) * TPM2_SUPPORTED_HASH_COUNT;
+
+pub const TPM2_SHA1_SIZE: usize = 16;
+pub const TPM2_SHA256_SIZE: usize = 32;
+pub const TPM2_SHA384_SIZE: usize = 48;
+pub const TPM2_SHA512_SIZE: usize = 64;
+pub const MAX_TPM2_HASH_SIZE: usize = TPM2_SHA512_SIZE;
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct Tpm2Digest {
+    pub alg_id: u16,
+    pub hash_size: usize,
+    pub total_size: usize,
+    pub hash: [u8; MAX_TPM2_HASH_SIZE],
+}
+
+impl Tpm2Digest {
+    pub fn new(alg_id: u16, value: &[u8]) -> Option<Tpm2Digest> {
+        let hash_size = Tpm2Digest::get_hash_size(alg_id)?;
+        if value.len() != hash_size {
+            return None;
+        }
+
+        let mut hash: [u8; MAX_TPM2_HASH_SIZE] = [0; MAX_TPM2_HASH_SIZE];
+        hash[..hash_size].copy_from_slice(value);
+
+        let total_size = hash_size + 2;
+
+        Some(Self {
+            alg_id,
+            hash_size,
+            total_size,
+            hash,
+        })
+    }
+
+    fn get_hash_size(alg_id: u16) -> Option<usize> {
+        match alg_id {
+            TPM2_HASH_ALG_ID_SHA256 => Some(TPM2_SHA256_SIZE),
+            TPM2_HASH_ALG_ID_SHA384 => Some(TPM2_SHA384_SIZE),
+            TPM2_HASH_ALG_ID_SHA512 => Some(TPM2_SHA512_SIZE),
+            _ => None,
+        }
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Tpm2Digest> {
+        let alg_id = u16::from_be_bytes([bytes[0], bytes[1]]);
+        let hash_size = Tpm2Digest::get_hash_size(alg_id)?;
+        if bytes.len() < hash_size + 2 {
+            return None;
+        }
+
+        Tpm2Digest::new(alg_id, &bytes[2..hash_size + 2])
+    }
+
+    pub fn to_bytes(&self, out_buffer: &mut [u8]) -> Option<usize> {
+        if out_buffer.len() < self.total_size {
+            return None;
+        }
+
+        out_buffer[..2].copy_from_slice(&self.alg_id.to_be_bytes());
+        out_buffer[2..self.hash_size + 2].copy_from_slice(&self.hash[..self.hash_size]);
+
+        Some(self.total_size)
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Tpm2Digests {
+    digests: Vec<Tpm2Digest>,
+    pub total_size: usize,
+    pub digests_count: usize,
+}
+
+impl Tpm2Digests {
+    pub fn new() -> Tpm2Digests {
+        Self {
+            digests: Vec::new(),
+            total_size: 0,
+            digests_count: 0,
+        }
+    }
+
+    pub fn push_digest(&mut self, digest: &Tpm2Digest) -> VtpmResult {
+        let hash_size = Tpm2Digest::get_hash_size(digest.alg_id);
+        if hash_size.is_none() {
+            return Err(VtpmError::InvalidParameter);
+        }
+
+        self.digests.push(*digest);
+        self.total_size += digest.total_size;
+        self.digests_count += 1;
+
+        Ok(())
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Tpm2Digests> {
+        let size = bytes.len();
+        let mut offset: usize = 0;
+        let mut digests = Tpm2Digests::default();
+
+        loop {
+            let dig = Tpm2Digest::from_bytes(&bytes[offset..])?;
+            offset = dig.total_size;
+            let _ = digests.push_digest(&dig);
+
+            if offset >= size {
+                break;
+            }
+        }
+
+        Some(digests)
+    }
+
+    pub fn to_bytes(&self, out_buffer: &mut [u8]) -> Option<usize> {
+        let mut offset: usize = 0;
+        let out_buffer_size = out_buffer.len();
+        let mut tmp_buffer: [u8; MAX_TPM2_HASH_SIZE + 2] = [0; MAX_TPM2_HASH_SIZE + 2];
+
+        if out_buffer_size < self.total_size {
+            return None;
+        }
+
+        for digest in &self.digests {
+            if digest.total_size > out_buffer_size - offset {
+                return None;
+            }
+            let size = digest.to_bytes(&mut tmp_buffer)?;
+            out_buffer[offset..offset + digest.total_size].copy_from_slice(&tmp_buffer[..size]);
+            offset += digest.total_size;
+        }
+
+        Some(offset)
+    }
+}
+
+impl Default for Tpm2Digests {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/kernel/src/vtpm/tpm_cmd/tpm2_extend.rs
+++ b/kernel/src/vtpm/tpm_cmd/tpm2_extend.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2022 - 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::vtpm::tpm_cmd::tpm2_command::Tpm2CommandHeader;
+use crate::vtpm::tpm_cmd::tpm2_digests::Tpm2Digests;
+use crate::vtpm::tpm_cmd::tpm2_digests::MAX_TPM2_DIGESTS_SIZE;
+use crate::vtpm::tpm_cmd::{VtpmError, VtpmResult};
+use crate::vtpm::tpm_cmd::{TPM2_COMMAND_HEADER_SIZE, TPM_ST_SESSIONS};
+
+/// TPM PcrExtend
+/// vTPM platform commands (SVSM spec, section 8.1 - SVSM_VTPM_QUERY)
+///
+/// The platform commmand values follow the values used by the
+/// Official TPM 2.0 Reference Implementation by Microsoft.
+///
+/// `ms-tpm-20-ref/TPMCmd/Simulator/include/TpmTcpProtocol.h`
+pub const TPM_CC_PCR_EXTEND: u32 = 0x182;
+
+pub const MAX_TPM_PCR_EXTEND_CMD_SIZE: usize = 1024;
+const TPM_PCR_HANDLE_SIZE: usize = 4;
+const TPM_PCR_EXTEND_AUTHORIZATION_INFO_SIZE: usize = 13;
+const TPM_PCR_DIGESTS_COUNT_SIZE: usize = 4;
+
+const TPM_PCR_EXTEND_PCR_HANDLE_OFFSET: usize = TPM2_COMMAND_HEADER_SIZE;
+const TPM_PCR_EXTEND_AUTHORIZATION_INFO_OFFSET: usize =
+    TPM_PCR_EXTEND_PCR_HANDLE_OFFSET + TPM_PCR_HANDLE_SIZE;
+const TPM_PCR_EXTEND_DIGESTS_COUNT_OFFSET: usize =
+    TPM_PCR_EXTEND_AUTHORIZATION_INFO_OFFSET + TPM_PCR_EXTEND_AUTHORIZATION_INFO_SIZE;
+const TPM_PCR_EXTEND_DIGESTS_VALUE_OFFSET: usize =
+    TPM_PCR_EXTEND_DIGESTS_COUNT_OFFSET + TPM_PCR_DIGESTS_COUNT_SIZE;
+
+const TPM_PCR_EXTEND_COMMAND_AUTHORIZATION_INFO: [u8; TPM_PCR_EXTEND_AUTHORIZATION_INFO_SIZE] = [
+    0x00, 0x00, 0x00, 0x09, 0x40, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+pub fn tpm2_pcr_extend_cmd(
+    digests: &Tpm2Digests,
+    pcr_index: u32,
+    tpm_command: &mut [u8; MAX_TPM_PCR_EXTEND_CMD_SIZE],
+) -> VtpmResult<usize> {
+    let mut tpm_cmd: [u8; MAX_TPM_PCR_EXTEND_CMD_SIZE] = [0u8; MAX_TPM_PCR_EXTEND_CMD_SIZE];
+    let digests_count = digests.digests_count as u32;
+
+    let tpm_cmd_size = (TPM2_COMMAND_HEADER_SIZE
+        + TPM_PCR_HANDLE_SIZE
+        + TPM_PCR_EXTEND_AUTHORIZATION_INFO_SIZE
+        + TPM_PCR_DIGESTS_COUNT_SIZE
+        + digests.total_size) as u32;
+
+    if tpm_cmd_size > MAX_TPM_PCR_EXTEND_CMD_SIZE as u32 {
+        return Err(VtpmError::InvalidParameter);
+    }
+
+    let mut digests_value_buffer: [u8; MAX_TPM2_DIGESTS_SIZE] = [0; MAX_TPM2_DIGESTS_SIZE];
+    let digests_value = digests.to_bytes(&mut digests_value_buffer);
+    if digests_value.is_none() {
+        return Err(VtpmError::InvalidParameter);
+    }
+
+    let cmd_header = Tpm2CommandHeader::new(TPM_ST_SESSIONS, tpm_cmd_size, TPM_CC_PCR_EXTEND);
+    let cmd_header_bytes: [u8; TPM2_COMMAND_HEADER_SIZE] = cmd_header.into();
+
+    // TPM2_PCR_EXTEND Command layout
+    // CommandHeader      <-- 10
+    // PcrHandle          <-- 4
+    // AuthorizationInfo  <-- 13
+    // DigestsCount       <-- 4
+    // DigestsValue       <-- n
+    tpm_cmd[..TPM2_COMMAND_HEADER_SIZE].copy_from_slice(&cmd_header_bytes);
+    tpm_cmd[TPM_PCR_EXTEND_PCR_HANDLE_OFFSET..TPM_PCR_EXTEND_AUTHORIZATION_INFO_OFFSET]
+        .copy_from_slice(&pcr_index.to_be_bytes());
+    tpm_cmd[TPM_PCR_EXTEND_AUTHORIZATION_INFO_OFFSET..TPM_PCR_EXTEND_DIGESTS_COUNT_OFFSET]
+        .copy_from_slice(&TPM_PCR_EXTEND_COMMAND_AUTHORIZATION_INFO);
+    tpm_cmd[TPM_PCR_EXTEND_DIGESTS_COUNT_OFFSET..TPM_PCR_EXTEND_DIGESTS_VALUE_OFFSET]
+        .copy_from_slice(&digests_count.to_be_bytes());
+    tpm_cmd[TPM_PCR_EXTEND_DIGESTS_VALUE_OFFSET..tpm_cmd_size as usize]
+        .copy_from_slice(&digests_value_buffer[..digests.total_size]);
+
+    // patch the size of tpm_cmd_pcr_extend
+    tpm_cmd[2..6].copy_from_slice(&tpm_cmd_size.to_be_bytes());
+
+    log::debug!("tpm_pcr_extend cmd:\n");
+    log::debug!("{:02x?}\n", &tpm_cmd[..tpm_cmd_size as usize]);
+
+    tpm_command.clone_from_slice(&tpm_cmd[..MAX_TPM_PCR_EXTEND_CMD_SIZE]);
+    Ok(tpm_cmd_size as usize)
+}


### PR DESCRIPTION
Hashed svsm version and extend to PCR0 before L2 OVMF launch.

Tested in self-host environment and can get PCR0 bank384 updated.

Only use SHA384 bank to extend SVSM version.